### PR TITLE
MagmaSat normalization bug fix

### DIFF
--- a/VESIcal/batchmodel.py
+++ b/VESIcal/batchmodel.py
@@ -432,6 +432,19 @@ class BatchFile(batchfile.BatchFile):
         """
         fluid_data = self.get_data().copy()
 
+        # check if None is passed for pressure, if so calculate SatP
+        if pressure is None:
+            pressures = self.calculate_saturation_pressure(
+                                                       temperature=temperature,
+                                                       model=model,
+                                                       **kwargs)
+            # add calcd SatPs to fluid_data df
+            fluid_data["SaturationP_bars_VESIcal"] = (
+                                        pressures["SaturationP_bars_VESIcal"])
+
+            # push that to pressure argument
+            pressure = "SaturationP_bars_VESIcal"
+
         # Check if the model passed as the attribute "model_type"
         # Currently only implemented for MagmaSat type models
         if hasattr(model, 'model_type') is True:
@@ -524,6 +537,7 @@ class BatchFile(batchfile.BatchFile):
 
                 if file_has_press:
                     pressure = row[press_name]
+
                 if temperature > 0 and pressure <= 0:
                     H2Ovals.append(np.nan)
                     CO2vals.append(np.nan)

--- a/tests/test_calculate.py
+++ b/tests/test_calculate.py
@@ -339,7 +339,7 @@ class TestEquilibriumFluidComp(unittest.TestCase):
         self.dixonMixed =          {'H2O': 0.7750859842655139, 'CO2': 0.2249140157344861}
         self.iaconomarzianoMixed = {'H2O': 0.811666221694067, 'CO2': 0.188333778305933}
         self.liuMixed =            {'H2O': 0.7066707740811572, 'CO2': 0.2933292259188428}
-        self.magmasat =            {'CO2': 0.219354223233457, 'H2O': 0.780645776766543}
+        self.magmasat =            {'CO2': 0.20391426033745, 'H2O': 0.79608573966255}
 
         self.shishkinaCarbon           = 1.0
         self.dixonCarbon               = 1.0


### PR DESCRIPTION
## Explanation of issue
MagmaSat inconsistently normalizes using "none" or "fixedvolatiles" creating inconsistent behavior, specifically when calculating the saturation pressure and the equilibrium fluid composition at that calculated saturation pressure. This fix forces "fixedvolatiles" normalization for all MagmaSat calculations by running the normalization step in the preprocess_sample() function.

## Detailed explanation and discussion with other devs
Here I paste some email conversations about this issue for transparency and so we can remember why we made this change down the line.

### Kayla
I just discovered a bug related to MagmaSat due to the way thermoengine takes inputs, namely, that it takes in H2O and CO2 values for the “system”, when with VESIcal when we pass a sample, it is sort of implied that the H2O and CO2 values are dissolved in the melt (not total in the system).

We fixed this issue where we would have gotten bad saturation pressures by getting the sample using the “fixedvolatiles” normalization inside that function. However we do NOT currently do that for calculate_equilibrium_fluid_comp(). Here’s why that’s a problem…

I realized the functionality to calculate EQ fluid comp with None pressure was broken for magmasat. In this case, we have told the user that if you pass None for the pressure, it will calculate and use the saturation pressure. I fixed that, but then… I would do something like:

`myfile.calculate_equilibrium_fluid_comp(temperature=1200, pressure=None)`

And it would tell me the sample was not saturated… but it should be internally calculating the saturation pressure! So, I calc’d it manually. Got a value for the saturation pressure of, let’s say, 2400 bars. Put that in as the pressure to get the eq fluid comp and… sample not saturated. I had to lower the P by around 15-20 bars to get it to saturate. I tracked down that this is due to the discrepancy between these functions (one normalizes with “fixedvolatiles” the other does not normalize at all). If you normalize using “fixedvolatiles” in both cases, everything works, and you can calculate eq fluid with None pressure just fine.

The solution should be to always normalize MagmaSat functions using “fixedvolatiles”. This is annoying to benchmark using the MagmaSat app, since you can only put in H2O and CO2 values for the “system”, but I can simply iterate a ton of  times until I get the app to spit out matching conditions with the matching dissolved H2O and CO2 contents.

But, this is a sort of substantial change, so I wanted to run it by both of you first. Thoughts?

### Simon
Thanks for doing all of this!

I guess this isn’t a problem with the other models because we don’t apply a normalisation? I have forgotten why doing a “fixedvolatiles” normalisation fixes the saturation pressures, could you remind me? I guess it would be nice if we could not normalise magmasat at all...

### Kayla
I think the reason is because the MagmaSat app is essentially doing a “fixedvolatiles” normalization during the computation, but only in some cases...

For all screenshots below, keep in mind that BLACK text is my inputs. All RED text is calculated by the app and cannot be edited. Which fields are red or black change depending on which calculation you are doing.

In the app, when calculating “Fluid+Psat from magma composition”, you input anhydrous oxides for majors, the “system hydr, wt%” area is unavailable, and you input H2O and CO2 contents under “Magma, Hydr, Wt %”. This treats the H2O and CO2 values as dissolved in the melt. See screenshot below which gives:

Fluid, mol frac = 0.79 H2O; 0.21 CO2
P, MPa = 245
<image001.png> 

However, when calculating “Fluid+magma from bulk composition”, you input H2O and CO2 into the “System Hydr, Wt%” boxes. This treats H2O and CO2 values as in the “system” so could be both dissolved and in the fluid. See screenshot below, which gives:

For given input P of 245 MPa (result from last calc)
Unsaturated
Of course it’s unsaturated, because it spits out 4.409 wt% H2O and 0.0846 wt% CO2 in the melt to get the “magma, hydr, wt%” values that it spits out (in red text, shown below)
<image002.png>

These produce different results, and IMO it’s not that intuitive. If I calculate the SatP and get 245 MPa, then use 245 MPa to calculate the fluid comp, it should darn well be saturated… right? Again, I think this is from the MagmaSat app differentiating user inputs for volatiles between “system” and “magma”.

Using VESIcal to calculate the fluid composition after doing ‘fixedvolatiles’ normalization (5.5 wt% H2O and 0.05 wt% CO2) at 1200 C and 245 MPa gives me XCO2 = 0.207, XH2O = 0.793. I can tweak the “system” H2O and CO2 inputs in the MagmaSat app (below) until I get ~5.5 wt% H2O and ~0.05 wt% CO2 in the calculated “mamga, hydr” box (red text, not user input; this is calculated by magmasat). With MagmaSat t 1200 C and 245 MPa I then get XCO2 = 0.211, XH2O = 0.789. That’s a match in my book. This method is what I think I thought VESIcal should be doing. So, IMO the best way to “correct” its behavior is to simply force normalization with “fixedvolatiles” when doing an equilibrium fluid composition calc in VESIcal with MgamaSat.

<image003.png>

Does that make sense?

### Simon
Thanks for setting all of that out. I think I follow. I trust whatever you judge to be the best solution, you have given it more thought that I have!

Some more thoughts that I had while thinking about it... (but feel free to ignore, they are probably just showing my confusion rather than being at all useful!)

Am I right in thinking that VESIcal right now is emulating the magmasat app directly, but that then makes it (VESIcal) internally inconsistent? So your change will make VESIcal internally consistent, but partially inconsistent with the app? And magmasat-in-VESIcal is anomalous compared to other models in VESIcal in that it is the only one with normalisation applied?

In that case, if we’re already going to be partially inconsistent with the app, is there any reason to not just abandon normalisation altogether (with normalisation an option if you want to recreate the app’s results, for testing for example)?

The other thing that occurred to me, is will changing the equilibrium-fluid-comp method affect the degassing path method? I think the other models rely on the equilibrium fluid calculations, but I forget how magmasat is coded…

### Penny
I have to admit I'm a bit confused. Kayla will your proposed change change the Sat P someone would get for a given MI composition? If not, I think it sounds good. If so, we might have a consistency problem

### Kayla
Some answers to your questions.

**Re: (in)consistencies with the MagmaSat app.**
I think there are multiple ways to look at it. It depends on how we want to define what the values for H2O and CO2 mean for a VESIcal Sample. In the MagmaSat app, “Fluid+PSat” treats them as dissolved in the melt while “Fluid+magma from bulk composition” treats them as being total volatiles for the system (dissolved plus fluid). However, in VESIcal, we don’t really have these two definitions for where the volatiles go. In my head, it should always be that the values input for a Sample represent volatiles dissolved in the melt, not in the entire “system”. IF we define VESIcal’s inputs this way (which, I think is what we are doing for all other models), that would make VESIcal internally consistent.

For example, a user might be asking one of these two questions:

1. I have a melt with 5 wt% H2O and 0.05 wt% CO2. What is the composition of a fluid that is in equilibrium with that melt?
In this case, we want to do “fixedvolatiles” normalization
2. I have some system with a silicate melt and 5 wt% H2O and 0.05 wt% CO2 in the system. Partition up the H2O and CO2 between melt and fluid and give me the composition of dissolved volatiles in the melt and the composition of the fluid.
In this case, we want no normalization
 
Either way it’s consistent with MagmaSat app depending on how you define it! In the app’s case, for “Fluid+magma from bulk composition”, the H2O and CO2 in the melt are outputs rather than inputs, so you have to iterate over what you input for the H2O and CO2 in the system to get the melt volatiles to match what you want. If we then compare VESIcal results to MagmaSat results that way, they match.

In the end it’s all rather confusing how MagmaSat does this… but what I know makes sense to me is that if one calc says I’m saturated at 245 MPa and the other doesn’t, that seems wrong…!

I think I’ve convinced myself that currently VESIcal is both internally inconsistent and also inconsistent with MagmaSat, if you take into consideration the bulk vs melt definitions.

**Re: is there any reason to not just abandon normalisation altogether / will changing the equilibrium-fluid-comp method affect the degassing path method?**
That’s a great question. I thought about this some more after you asked about whether the degassing path calculation would be affected. It would not be, BUT, I think we maybe should be doing “fixedvolatiles” normalization there, too. I keep coming back to: If we define a Sample’s H2O and CO2 as being in the melt, then we should be doing ‘fixedvolatiles’ normalization. This is because thermoengine equilibrate_tp takes in a bulk composition, while VESIcal is taking in a melt composition. So we need to translate between the two to make VESIcal internally consistent.

**Re: will your proposed change change the Sat P someone would get for a given MI composition?**
No. The saturation pressure calculation already does “fixedvolatiles” normalization, so there would be no change there.

**Final thoughts:**
I applied “fixedvolatiles” normalization to MamgaSat’s preprocess_sample() method and ran the unittests. They all pass except for two equilibrium fluid composition tests, which are off by a tiny amount.

```
======================================================================
FAIL: test_calculate_wtpt_mixed (tests.test_calculate.TestEquilibriumFluidComp)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/kiacovin/Dropbox/Research/Published Papers/2021_VESIcal/__TheCode/VESIcal_master/VESIcal/tests/test_calculate.py", line 398, in test_calculate_wtpt_mixed
    self.assertAlmostEqual(calcd_result[key], known_result[key], places=4)
AssertionError: 0.203914260339005 != 0.219354223233457 within 4 places (0.015439962894451986 difference)

======================================================================
FAIL: test_calculation_molox_mixed (tests.test_calculate.TestEquilibriumFluidComp)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/kiacovin/Dropbox/Research/Published Papers/2021_VESIcal/__TheCode/VESIcal_master/VESIcal/tests/test_calculate.py", line 429, in test_calculation_molox_mixed
    self.assertAlmostEqual(calcd_result[key], known_result[key], places=4)
AssertionError: 0.203914260339005 != 0.219354223233457 within 4 places (0.015439962894451986 difference)
----------------------------------------------------------------------
```

I also ran the manuscript notebook with the change, and everything looks good with only minor equilibrium fluid composition changes to some samples. With those tests, I’m convinced we should apply “fixedvolatiles” to all magmasat samples, in order to translate between VESIcal’s input of melt volatiles to thermoengine’s input of bulk volatiles.

If you’re both okay with this, I’ll make the change.

### Penny
Sounds good. I agree the calculations need to be reversible, which it sounds like this change makes them. And tbh it's all within the error of the model anyway

### Simon
Ok- sounds good!