### PR TITLE
Removes requirement that species=None when checking for 'normalizatio…

### DIFF
--- a/VESIcal/sample_class.py
+++ b/VESIcal/sample_class.py
@@ -196,9 +196,9 @@ class Sample(object):
                 raise core.InputError("The oxide name provided in oxide_masses is not recognised.")
 
         # Fetch the default return types if not specified in function call
-        if normalization is None and species is None:
+        if normalization is None:
             normalization = self.default_normalization
-        if units is None and species is None:
+        if units is None:
             units = self.default_units
 
         # Check whether to exclude volatiles


### PR DESCRIPTION
Simon, I'm hoping you can set me straight here. This is a TINY change, so hopefully easy for you to address. Want to make sure I'm not crazy. I was chasing down some errors (still am) in another project that uses copy-pasted (and tweaked) methods such as get_composition() for the custom Sample class that I'm making for that project. I realized that when asking for the composition of a particular species in my Sample, it does not recognize the Sample's default units. This is the same for the Sample's default normalization that has been set. I made two small changes to correct this, but I'm not sure if this behavior was intentional? Would you mind having a quick look? Thanks!