### PR TITLE
I *think* I've implemented this properly for Liu but need a code review!

### DIFF
--- a/VESIcal/calibration_checks.py
+++ b/VESIcal/calibration_checks.py
@@ -153,7 +153,10 @@ crmsg_LessThan_description = ("The {model_name} model is calibrated for "
 
 
 def crf_Between(calibval, paramval):
-    return paramval >= calibval[0] and paramval <= calibval[1]
+    if isinstance(paramval, np.ndarray):
+        return paramval.any() >= calibval[0] and paramval.any() <= calibval[1]
+    else:
+        return paramval >= calibval[0] and paramval <= calibval[1]
 
 
 crmsg_Between_pass = ("The {param_name} ({param_val:.1f} {units}) is between "

--- a/VESIcal/model_classes.py
+++ b/VESIcal/model_classes.py
@@ -585,9 +585,12 @@ class MixedFluid(Model):
         wtm0s, wtm1s = (wtptoxides[self.volatile_species[0]],
                         wtptoxides[self.volatile_species[1]])
 
-        if pressure == 'saturation':
-            p0 = self.calculate_saturation_pressure(sample, **kwargs)
-            pressures = np.linspace(p0, final_pressure, steps)
+        if isinstance(pressure, str):
+            if pressure == 'saturation':
+                p0 = self.calculate_saturation_pressure(sample, **kwargs)
+                pressures = np.linspace(p0, final_pressure, steps)
+            else:
+                raise core.InputError("Pressure string not understood.")
         elif type(pressure) == float or type(pressure) == int:
             pressures = np.linspace(pressure, final_pressure, steps)
         elif type(pressure) == list or type(pressure) == np.ndarray:

--- a/VESIcal/models/liu.py
+++ b/VESIcal/models/liu.py
@@ -10,10 +10,6 @@ import warnings as w
 import sympy
 from scipy.optimize import root_scalar
 
-crmsg_0bar_fail = ("{param_name} ({param_val:.1f} {units}) is less than 0 bars. ")
-crmsg_5000bar_fail = ("{param_name} exceeds 5000 bar, which is the recommended upper calibration"
-                      " limit of rht Liu et al. (2005) model. ")
-
 
 class water(model_classes.Model):
     """
@@ -43,28 +39,17 @@ class water(model_classes.Model):
 
         self.set_calibration_ranges([
             calibration_checks.CalibrationRange(
-                'pressure', 0, calibration_checks.crf_GreaterThan, 'bar',
+                'pressure', [0, 5000.0], calibration_checks.crf_Between, 'bar',
                 'Liu et al. (2005) water',
-                fail_msg=crmsg_0bar_fail,
-                pass_msg=calibration_checks.crmsg_GreaterThan_pass,
-                description_msg=calibration_checks.crmsg_GreaterThan_description),
+                fail_msg=calibration_checks.crmsg_Between_fail,
+                pass_msg=calibration_checks.crmsg_Between_pass,
+                description_msg=calibration_checks.crmsg_Between_description),
             calibration_checks.CalibrationRange(
-                'pressure', 5000, calibration_checks.crf_LessThan, 'bar',
+                'temperature', [700.0, 1200], calibration_checks.crf_Between, 'oC',
                 'Liu et al. (2005) water',
-                fail_msg=crmsg_5000bar_fail,
-                pass_msg=calibration_checks.crmsg_LessThan_pass,
-                description_msg=calibration_checks.crmsg_LessThan_description),
-            #     'pressure', [0, 5000.0], calibration_checks.crf_Between, 'bar',
-            #     'Liu et al. (2005) water',
-            #     fail_msg=calibration_checks.crmsg_Between_fail,
-            #     pass_msg=calibration_checks.crmsg_Between_pass,
-            #     description_msg=calibration_checks.crmsg_Between_description),
-            # calibration_checks.CalibrationRange(
-            #     'temperature', [700.0, 1200], calibration_checks.crf_Between, 'oC',
-            #     'Liu et al. (2005) water',
-            #     fail_msg=calibration_checks.crmsg_Between_fail,
-            #     pass_msg=calibration_checks.crmsg_Between_pass,
-            #     description_msg=calibration_checks.crmsg_Between_description),
+                fail_msg=calibration_checks.crmsg_Between_fail,
+                pass_msg=calibration_checks.crmsg_Between_pass,
+                description_msg=calibration_checks.crmsg_Between_description),
             calibration_checks.CalibrationRange(
                 'sample', None, crf_WaterComp, None, None,
                 fail_msg=crmsg_WaterComp_fail,
@@ -251,29 +236,17 @@ class carbon(model_classes.Model):
 
         self.set_calibration_ranges([
             calibration_checks.CalibrationRange(
-                'pressure', 0, calibration_checks.crf_GreaterThan, 'bar',
-                'Liu et al. (2005) water',
-                fail_msg=crmsg_0bar_fail,
-                pass_msg=calibration_checks.crmsg_GreaterThan_pass,
-                description_msg=calibration_checks.crmsg_GreaterThan_description),
+                'pressure', [0, 5000.0], calibration_checks.crf_Between, 'bar',
+                'Liu et al. (2005) Carbon',
+                fail_msg=calibration_checks.crmsg_Between_fail,
+                pass_msg=calibration_checks.crmsg_Between_pass,
+                description_msg=calibration_checks.crmsg_Between_description),
             calibration_checks.CalibrationRange(
-                'pressure', 5000, calibration_checks.crf_LessThan, 'bar',
-                'Liu et al. (2005) water',
-                fail_msg=crmsg_5000bar_fail,
-                pass_msg=calibration_checks.crmsg_LessThan_pass,
-                description_msg=calibration_checks.crmsg_LessThan_description),
-            # calibration_checks.CalibrationRange(
-            #     'pressure', [0, 5000.0], calibration_checks.crf_Between, 'bar',
-            #     'Liu et al. (2005) Carbon',
-            #     fail_msg=calibration_checks.crmsg_Between_fail,
-            #     pass_msg=calibration_checks.crmsg_Between_pass,
-            #     description_msg=calibration_checks.crmsg_Between_description),
-            # calibration_checks.CalibrationRange(
-            #     'temperature', [700.0, 1200], calibration_checks.crf_Between, 'oC',
-            #     'Liu et al. (2005) Carbon',
-            #     fail_msg=calibration_checks.crmsg_Between_fail,
-            #     pass_msg=calibration_checks.crmsg_Between_pass,
-            #     description_msg=calibration_checks.crmsg_Between_description),
+                'temperature', [700.0, 1200], calibration_checks.crf_Between, 'oC',
+                'Liu et al. (2005) Carbon',
+                fail_msg=calibration_checks.crmsg_Between_fail,
+                pass_msg=calibration_checks.crmsg_Between_pass,
+                description_msg=calibration_checks.crmsg_Between_description),
             calibration_checks.CalibrationRange(
                 'sample', None, crf_CarbonComp, None, None,
                 fail_msg=crmsg_CarbonComp_fail,
@@ -553,27 +526,15 @@ for ox in carboncomprange.keys():
 
 mixed.models[0].set_calibration_ranges([
     calibration_checks.CalibrationRange(
-        'pressure', 0, calibration_checks.crf_GreaterThan, 'bar',
-        'Liu et al. (2005) water',
-        fail_msg=crmsg_0bar_fail,
-        pass_msg=calibration_checks.crmsg_GreaterThan_pass,
-        description_msg=calibration_checks.crmsg_GreaterThan_description),
+        'pressure', [0, 5000.0], calibration_checks.crf_Between, 'bar', 'Liu et al. (2005)',
+        fail_msg=calibration_checks.crmsg_Between_fail,
+        pass_msg=calibration_checks.crmsg_Between_pass,
+        description_msg=calibration_checks.crmsg_Between_description),
     calibration_checks.CalibrationRange(
-        'pressure', 5000, calibration_checks.crf_LessThan, 'bar',
-        'Liu et al. (2005) water',
-        fail_msg=crmsg_5000bar_fail,
-        pass_msg=calibration_checks.crmsg_LessThan_pass,
-        description_msg=calibration_checks.crmsg_LessThan_description),
-    # calibration_checks.CalibrationRange(
-    #     'pressure', [0, 5000.0], calibration_checks.crf_Between, 'bar', 'Liu et al. (2005)',
-    #     fail_msg=calibration_checks.crmsg_Between_fail,
-    #     pass_msg=calibration_checks.crmsg_Between_pass,
-    #     description_msg=calibration_checks.crmsg_Between_description),
-    # calibration_checks.CalibrationRange(
-    #     'temperature', [700.0, 1200], calibration_checks.crf_Between, 'oC', 'Liu et al. (2005)',
-    #     fail_msg=calibration_checks.crmsg_Between_fail,
-    #     pass_msg=calibration_checks.crmsg_Between_pass,
-    #     description_msg=calibration_checks.crmsg_Between_description),
+        'temperature', [700.0, 1200], calibration_checks.crf_Between, 'oC', 'Liu et al. (2005)',
+        fail_msg=calibration_checks.crmsg_Between_fail,
+        pass_msg=calibration_checks.crmsg_Between_pass,
+        description_msg=calibration_checks.crmsg_Between_description),
     calibration_checks.CalibrationRange(
         'sample', None, crf_MixedComp, None, None,
         fail_msg=crmsg_Comp_fail,

--- a/VESIcal/models/liu.py
+++ b/VESIcal/models/liu.py
@@ -10,6 +10,10 @@ import warnings as w
 import sympy
 from scipy.optimize import root_scalar
 
+crmsg_0bar_fail = ("{param_name} ({param_val:.1f} {units}) is less than 0 bars. ")
+crmsg_5000bar_fail = ("{param_name} exceeds 5000 bar, which is the recommended upper calibration"
+                      " limit of rht Liu et al. (2005) model. ")
+
 
 class water(model_classes.Model):
     """
@@ -39,17 +43,28 @@ class water(model_classes.Model):
 
         self.set_calibration_ranges([
             calibration_checks.CalibrationRange(
-                'pressure', [0, 5000.0], calibration_checks.crf_Between, 'bar',
+                'pressure', 0, calibration_checks.crf_GreaterThan, 'bar',
                 'Liu et al. (2005) water',
-                fail_msg=calibration_checks.crmsg_Between_fail,
-                pass_msg=calibration_checks.crmsg_Between_pass,
-                description_msg=calibration_checks.crmsg_Between_description),
+                fail_msg=crmsg_0bar_fail,
+                pass_msg=calibration_checks.crmsg_GreaterThan_pass,
+                description_msg=calibration_checks.crmsg_GreaterThan_description),
             calibration_checks.CalibrationRange(
-                'temperature', [700.0, 1200], calibration_checks.crf_Between, 'oC',
+                'pressure', 5000, calibration_checks.crf_LessThan, 'bar',
                 'Liu et al. (2005) water',
-                fail_msg=calibration_checks.crmsg_Between_fail,
-                pass_msg=calibration_checks.crmsg_Between_pass,
-                description_msg=calibration_checks.crmsg_Between_description),
+                fail_msg=crmsg_5000bar_fail,
+                pass_msg=calibration_checks.crmsg_LessThan_pass,
+                description_msg=calibration_checks.crmsg_LessThan_description),
+            #     'pressure', [0, 5000.0], calibration_checks.crf_Between, 'bar',
+            #     'Liu et al. (2005) water',
+            #     fail_msg=calibration_checks.crmsg_Between_fail,
+            #     pass_msg=calibration_checks.crmsg_Between_pass,
+            #     description_msg=calibration_checks.crmsg_Between_description),
+            # calibration_checks.CalibrationRange(
+            #     'temperature', [700.0, 1200], calibration_checks.crf_Between, 'oC',
+            #     'Liu et al. (2005) water',
+            #     fail_msg=calibration_checks.crmsg_Between_fail,
+            #     pass_msg=calibration_checks.crmsg_Between_pass,
+            #     description_msg=calibration_checks.crmsg_Between_description),
             calibration_checks.CalibrationRange(
                 'sample', None, crf_WaterComp, None, None,
                 fail_msg=crmsg_WaterComp_fail,
@@ -236,17 +251,29 @@ class carbon(model_classes.Model):
 
         self.set_calibration_ranges([
             calibration_checks.CalibrationRange(
-                'pressure', [0, 5000.0], calibration_checks.crf_Between, 'bar',
-                'Liu et al. (2005) Carbon',
-                fail_msg=calibration_checks.crmsg_Between_fail,
-                pass_msg=calibration_checks.crmsg_Between_pass,
-                description_msg=calibration_checks.crmsg_Between_description),
+                'pressure', 0, calibration_checks.crf_GreaterThan, 'bar',
+                'Liu et al. (2005) water',
+                fail_msg=crmsg_0bar_fail,
+                pass_msg=calibration_checks.crmsg_GreaterThan_pass,
+                description_msg=calibration_checks.crmsg_GreaterThan_description),
             calibration_checks.CalibrationRange(
-                'temperature', [700.0, 1200], calibration_checks.crf_Between, 'oC',
-                'Liu et al. (2005) Carbon',
-                fail_msg=calibration_checks.crmsg_Between_fail,
-                pass_msg=calibration_checks.crmsg_Between_pass,
-                description_msg=calibration_checks.crmsg_Between_description),
+                'pressure', 5000, calibration_checks.crf_LessThan, 'bar',
+                'Liu et al. (2005) water',
+                fail_msg=crmsg_5000bar_fail,
+                pass_msg=calibration_checks.crmsg_LessThan_pass,
+                description_msg=calibration_checks.crmsg_LessThan_description),
+            # calibration_checks.CalibrationRange(
+            #     'pressure', [0, 5000.0], calibration_checks.crf_Between, 'bar',
+            #     'Liu et al. (2005) Carbon',
+            #     fail_msg=calibration_checks.crmsg_Between_fail,
+            #     pass_msg=calibration_checks.crmsg_Between_pass,
+            #     description_msg=calibration_checks.crmsg_Between_description),
+            # calibration_checks.CalibrationRange(
+            #     'temperature', [700.0, 1200], calibration_checks.crf_Between, 'oC',
+            #     'Liu et al. (2005) Carbon',
+            #     fail_msg=calibration_checks.crmsg_Between_fail,
+            #     pass_msg=calibration_checks.crmsg_Between_pass,
+            #     description_msg=calibration_checks.crmsg_Between_description),
             calibration_checks.CalibrationRange(
                 'sample', None, crf_CarbonComp, None, None,
                 fail_msg=crmsg_CarbonComp_fail,
@@ -526,15 +553,27 @@ for ox in carboncomprange.keys():
 
 mixed.models[0].set_calibration_ranges([
     calibration_checks.CalibrationRange(
-        'pressure', [0, 5000.0], calibration_checks.crf_Between, 'bar', 'Liu et al. (2005)',
-        fail_msg=calibration_checks.crmsg_Between_fail,
-        pass_msg=calibration_checks.crmsg_Between_pass,
-        description_msg=calibration_checks.crmsg_Between_description),
+        'pressure', 0, calibration_checks.crf_GreaterThan, 'bar',
+        'Liu et al. (2005) water',
+        fail_msg=crmsg_0bar_fail,
+        pass_msg=calibration_checks.crmsg_GreaterThan_pass,
+        description_msg=calibration_checks.crmsg_GreaterThan_description),
     calibration_checks.CalibrationRange(
-        'temperature', [700.0, 1200], calibration_checks.crf_Between, 'oC', 'Liu et al. (2005)',
-        fail_msg=calibration_checks.crmsg_Between_fail,
-        pass_msg=calibration_checks.crmsg_Between_pass,
-        description_msg=calibration_checks.crmsg_Between_description),
+        'pressure', 5000, calibration_checks.crf_LessThan, 'bar',
+        'Liu et al. (2005) water',
+        fail_msg=crmsg_5000bar_fail,
+        pass_msg=calibration_checks.crmsg_LessThan_pass,
+        description_msg=calibration_checks.crmsg_LessThan_description),
+    # calibration_checks.CalibrationRange(
+    #     'pressure', [0, 5000.0], calibration_checks.crf_Between, 'bar', 'Liu et al. (2005)',
+    #     fail_msg=calibration_checks.crmsg_Between_fail,
+    #     pass_msg=calibration_checks.crmsg_Between_pass,
+    #     description_msg=calibration_checks.crmsg_Between_description),
+    # calibration_checks.CalibrationRange(
+    #     'temperature', [700.0, 1200], calibration_checks.crf_Between, 'oC', 'Liu et al. (2005)',
+    #     fail_msg=calibration_checks.crmsg_Between_fail,
+    #     pass_msg=calibration_checks.crmsg_Between_pass,
+    #     description_msg=calibration_checks.crmsg_Between_description),
     calibration_checks.CalibrationRange(
         'sample', None, crf_MixedComp, None, None,
         fail_msg=crmsg_Comp_fail,

--- a/tests/test_calculate.py
+++ b/tests/test_calculate.py
@@ -1,5 +1,21 @@
 import unittest
 import VESIcal as v
+import numpy as np
+
+def print_msg_box(msg, indent=1, width=None, title=None):
+    """Print message-box with optional title."""
+    lines = msg.split('\n')
+    space = " " * indent
+    if not width:
+        width = max(map(len, lines))
+    box = f'╔{"═" * (width + indent * 2)}╗\n'  # upper_border
+    if title:
+        box += f'║{space}{title:<{width}}{space}║\n'  # title
+        box += f'║{space}{"-" * len(title):<{width}}{space}║\n'  # underscore
+    box += ''.join([f'║{space}{line:<{width}}{space}║\n' for line in lines])
+    box += f'╚{"═" * (width + indent * 2)}╝'  # lower_border
+    print("\n")
+    print(box)
 
 class TestDissolvedVolatiles(unittest.TestCase):
     def setUp(self):
@@ -99,6 +115,7 @@ class TestDissolvedVolatiles(unittest.TestCase):
                             }
 
     def test_calculate_single_wtpt_mixed(self):
+        print_msg_box("TestDissolvedVolatiles \nsingle_wtpt_mixed")
         for model in self.mixed_dict.keys():
             calcd_result = v.calculate_dissolved_volatiles(self.sample_wtpt, pressure=1000, temperature=1000, X_fluid=0.5, model=model, verbose=False).result
             known_result = self.mixed_dict[model]['wtpt_oxides']
@@ -112,20 +129,23 @@ class TestDissolvedVolatiles(unittest.TestCase):
     #         for k in calcd_result.keys():
     #             self.assertAlmostEqual(calcd_result[k], known_result[k], places=4)
 
-    def test_calculate_single__wtpt_nonmixed(self):
+    def test_calculate_single_wtpt_nonmixed(self):
+        print_msg_box("TestDissolvedVolatiles \nsingle_wtpt_nonmixed")
         for model in self.nonmixed_dict.keys():
             calcd_result = v.calculate_dissolved_volatiles(self.sample_wtpt, pressure=1000, temperature=1000, X_fluid=0.5, model=model, verbose=False).result
             known_result = self.nonmixed_dict[model]['wtpt_oxides']
             self.assertAlmostEqual(calcd_result, known_result, places=4)
 
-    def test_calculate_single__molox_mixed(self):
+    def test_calculate_single_molox_mixed(self):
+        print_msg_box("TestDissolvedVolatiles \nsingle_molox_mixed")
         for model in self.mixed_dict.keys():
             calcd_result = v.calculate_dissolved_volatiles(self.sample_molox, pressure=1000, temperature=1000, X_fluid=0.5, model=model, verbose=False).result
             known_result = self.mixed_dict[model]['mol_oxides']
             for k in calcd_result.keys():
                 self.assertAlmostEqual(calcd_result[k], known_result[k], places=4)
 
-    def test_calculate_single__molox_nonmixed(self):
+    def test_calculate_single_molox_nonmixed(self):
+        print_msg_box("TestDissolvedVolatiles \nsingle_molox_nonmixed")
         for model in self.nonmixed_dict.keys():
             calcd_result = v.calculate_dissolved_volatiles(self.sample_molox, pressure=1000, temperature=1000, X_fluid=0.5, model=model, verbose=False).result
             known_result = self.nonmixed_dict[model]['mol_oxides']
@@ -226,12 +246,14 @@ class TestSaturationPressure(unittest.TestCase):
                           }
 
     def test_calculate_single_wtpt_mixed(self):
+        print_msg_box("TestSaturationPressure \nsingle_wtpt_mixed")
         for model in self.mixed_dict.keys():
             calcd_result = v.calculate_saturation_pressure(self.sample_wtpt, temperature=self.temperature, model=model, verbose=False).result
             known_result = self.mixed_dict[model]
             self.assertAlmostEqual(calcd_result, known_result, places=4)
 
     def test_calculate_batch_wtpt_mixed(self):
+        print_msg_box("TestSaturationPressure \nbatch_wtpt_mixed")
         for model in self.mixed_dict.keys():
             batch_result = self.batch_wtpt.calculate_saturation_pressure(temperature=self.temperature, model=model, verbose=True)
             calcd_result = batch_result['SaturationP_bars_VESIcal'].loc['test_samp']
@@ -240,12 +262,14 @@ class TestSaturationPressure(unittest.TestCase):
             self.assertAlmostEqual(calcd_result, known_result, places=4)
 
     def test_calculate_single_wtpt_carbon(self):
+        print_msg_box("TestSaturationPressure \nsingle_wtpt_carbon")
         for model in self.carbon_dict.keys():
             calcd_result = v.calculate_saturation_pressure(self.sample_wtpt, temperature=self.temperature, model=model, verbose=False).result
             known_result = self.carbon_dict[model]
             self.assertAlmostEqual(calcd_result, known_result, places=4)
 
     def test_calculate_batch_wtpt_carbon(self):
+        print_msg_box("TestSaturationPressure \nbatch_wtpt_carbon")
         for model in self.carbon_dict.keys():
             batch_result = self.batch_wtpt.calculate_saturation_pressure(temperature=self.temperature, model=model, verbose=False)
             calcd_result = batch_result['SaturationP_bars_VESIcal'].loc['test_samp']
@@ -253,12 +277,14 @@ class TestSaturationPressure(unittest.TestCase):
             self.assertAlmostEqual(calcd_result, known_result, places=4)
 
     def test_calculate_single_wtpt_water(self):
+        print_msg_box("TestSaturationPressure \nsingle_wtpt_water")
         for model in self.water_dict.keys():
             calcd_result = v.calculate_saturation_pressure(self.sample_wtpt, temperature=self.temperature, model=model, verbose=False).result
             known_result = self.water_dict[model]
             self.assertAlmostEqual(calcd_result, known_result, places=4)
 
     def test_calculate_batch_wtpt_water(self):
+        print_msg_box("TestSaturationPressure \nbatch_wtpt_water")
         for model in self.water_dict.keys():
             batch_result = self.batch_wtpt.calculate_saturation_pressure(temperature=self.temperature, model=model, verbose=False)
             calcd_result = batch_result['SaturationP_bars_VESIcal'].loc['test_samp']
@@ -266,12 +292,14 @@ class TestSaturationPressure(unittest.TestCase):
             self.assertAlmostEqual(calcd_result, known_result, places=4)
 
     def test_calculation_single_molox_mixed(self):
+        print_msg_box("TestSaturationPressure \nsingle_molox_mixed")
         for model in self.mixed_dict.keys():
             calcd_result = v.calculate_saturation_pressure(self.sample_molox, temperature=self.temperature, model=model, verbose=False).result
             known_result = self.mixed_dict[model]
             self.assertAlmostEqual(calcd_result, known_result, places=4)
 
     def test_calculation_batch_molox_mixed(self):
+        print_msg_box("TestSaturationPressure \nbatch_molox_mixed")
         for model in self.mixed_dict.keys():
             batch_result = self.batch_molox.calculate_saturation_pressure(temperature=self.temperature, model=model, verbose=True)
             calcd_result = batch_result['SaturationP_bars_VESIcal'].loc['test_samp']
@@ -280,12 +308,14 @@ class TestSaturationPressure(unittest.TestCase):
             self.assertAlmostEqual(calcd_result, known_result, places=4)
 
     def test_calculate_single_molox_carbon(self):
+        print_msg_box("TestSaturationPressure \nsingle_molox_carbon")
         for model in self.carbon_dict.keys():
             calcd_result = v.calculate_saturation_pressure(self.sample_molox, temperature=self.temperature, model=model, verbose=False).result
             known_result = self.carbon_dict[model]
             self.assertAlmostEqual(calcd_result, known_result, places=4)
 
     def test_calculate_batch_molox_carbon(self):
+        print_msg_box("TestSaturationPressure \nbatch_molox_carbon")
         for model in self.carbon_dict.keys():
             batch_result = self.batch_molox.calculate_saturation_pressure(temperature=self.temperature, model=model, verbose=False)
             calcd_result = batch_result['SaturationP_bars_VESIcal'].loc['test_samp']
@@ -293,17 +323,83 @@ class TestSaturationPressure(unittest.TestCase):
             self.assertAlmostEqual(calcd_result, known_result, places=4)
 
     def test_calculate_single_molox_water(self):
+        print_msg_box("TestSaturationPressure \nsingle_molox_water")
         for model in self.water_dict.keys():
             calcd_result = v.calculate_saturation_pressure(self.sample_molox, temperature=self.temperature, model=model, verbose=False).result
             known_result = self.water_dict[model]
             self.assertAlmostEqual(calcd_result, known_result, places=4)
 
     def test_calculate_batch_molox_water(self):
+        print_msg_box("TestSaturationPressure \nbatch_molox_water")
         for model in self.water_dict.keys():
             batch_result = self.batch_molox.calculate_saturation_pressure(temperature=self.temperature, model=model, verbose=False)
             calcd_result = batch_result['SaturationP_bars_VESIcal'].loc['test_samp']
             known_result = self.water_dict[model]
             self.assertAlmostEqual(calcd_result, known_result, places=4)
+
+
+class TestDegassingPath(unittest.TestCase):
+    """ Only checks for exceptions thrown, not that result is correct!!
+    """
+    def setUp(self):
+        self.majors_wtpt = {'SiO2':    47.95,
+                         'TiO2':    1.67,
+                         'Al2O3':   17.32,
+                         'FeO':     10.24,
+                         'Fe2O3':   0.1,
+                         'MgO':     5.76,
+                         'CaO':     10.93,
+                         'Na2O':    3.45,
+                         'K2O':     1.99,
+                         'P2O5':    0.51,
+                         'MnO':     0.1,
+                         'H2O':     2.0,
+                         'CO2':     0.1}
+        
+        self.sample = v.Sample(self.majors_wtpt)
+
+        # Set conditions of calculation
+        self.temperature = 1000
+        self.pressure_init = 500
+        self.pressure_final = 300
+        self.step_size = -1
+        self.pressure_array = np.arange(self.pressure_init, self.pressure_final, self.step_size)
+
+        # Grab mixed models
+        self.mixed_model_names = v.get_model_names("mixed")
+        self.mixed_model_names.append("MagmaSat") # include MagmaSat
+    
+    def test_calculate_degassing_path_simple(self):
+        """ Only starting pressure supplied
+        """
+        print_msg_box("TestDegassingPath \nsimple")
+                                       
+        for model_name in self.mixed_model_names:
+            result = v.calculate_degassing_path(sample=self.sample,
+                                                temperature=self.temperature,
+                                                pressure=self.pressure_init, model=model_name)
+    
+    def test_calculate_degassing_path_init_to_final(self):
+        """ Uses initial and final pressures, as floats
+        """
+        print_msg_box("TestDegassingPath \ninit_to_final")
+        for model_name in self.mixed_model_names:
+            result = v.calculate_degassing_path(sample=self.sample,
+                                                temperature=self.temperature,
+                                                pressure=self.pressure_init, 
+                                                final_pressure = self.pressure_final,
+                                                model=model_name)
+    
+    def test_calculate_degassing_path_array(self):
+        """ Uses np.ndarray() object for pressures
+        """
+        print_msg_box("TestDegassingPath \narray")
+                  
+        for model_name in self.mixed_model_names:
+            result = v.calculate_degassing_path(sample=self.sample,
+                                                temperature=self.temperature,
+                                                pressure=self.pressure_array, model=model_name)
+
 
 class TestEquilibriumFluidComp(unittest.TestCase):
     def setUp(self):
@@ -387,6 +483,7 @@ class TestEquilibriumFluidComp(unittest.TestCase):
                           }
 
     def test_calculate_wtpt_mixed(self):
+        print_msg_box("TestEquilibriumFluidComp \nwtpt_mixed")
         for model in self.mixed_dict.keys():
             calcd_result = v.calculate_equilibrium_fluid_comp(self.sample_wtpt,
                                                               temperature=self.temperature,
@@ -398,6 +495,7 @@ class TestEquilibriumFluidComp(unittest.TestCase):
                 self.assertAlmostEqual(calcd_result[key], known_result[key], places=4)
 
     def test_calculate_wtpt_carbon(self):
+        print_msg_box("TestEquilibriumFluidComp \nwtpt_carbon")
         for model in self.carbon_dict.keys():
             calcd_result = v.calculate_equilibrium_fluid_comp(self.sample_wtpt,
                                                               temperature=self.temperature,
@@ -408,6 +506,7 @@ class TestEquilibriumFluidComp(unittest.TestCase):
             self.assertAlmostEqual(calcd_result, known_result, places=4)
 
     def test_calculate_wtpt_water(self):
+        print_msg_box("TestEquilibriumFluidComp \nwtpt_water")
         for model in self.water_dict.keys():
             calcd_result = v.calculate_equilibrium_fluid_comp(self.sample_wtpt,
                                                               temperature=self.temperature,
@@ -418,6 +517,7 @@ class TestEquilibriumFluidComp(unittest.TestCase):
             self.assertAlmostEqual(calcd_result, known_result, places=4)
 
     def test_calculation_molox_mixed(self):
+        print_msg_box("TestEquilibriumFluidComp \nmolox_mixed")
         for model in self.mixed_dict.keys():
             calcd_result = v.calculate_equilibrium_fluid_comp(self.sample_molox,
                                                               temperature=self.temperature,
@@ -429,6 +529,7 @@ class TestEquilibriumFluidComp(unittest.TestCase):
                 self.assertAlmostEqual(calcd_result[key], known_result[key], places=4)
 
     def test_calculate_molox_carbon(self):
+        print_msg_box("TestEquilibriumFluidComp \nmolox_carbon")
         for model in self.carbon_dict.keys():
             calcd_result = v.calculate_equilibrium_fluid_comp(self.sample_molox,
                                                               temperature=self.temperature,
@@ -439,6 +540,7 @@ class TestEquilibriumFluidComp(unittest.TestCase):
             self.assertAlmostEqual(calcd_result, known_result, places=4)
 
     def test_calculate_molox_water(self):
+        print_msg_box("TestEquilibriumFluidComp \nmolox_water")
         for model in self.water_dict.keys():
             calcd_result = v.calculate_equilibrium_fluid_comp(self.sample_molox,
                                                               temperature=self.temperature,
@@ -533,12 +635,14 @@ class TestLiquidViscosity(unittest.TestCase):
                                     'F2O':     0.748}
 
     def test_calculate_single_wtpt(self):
+        print_msg_box("TestLiquidViscosity \nsingle_wtpt")
         calcd_result = v.calculate_liquid_viscosity(self.sample_wtpt,
                                             temperature=self.temperature).result
         known_result = self.giordano_default_viscosity
         self.assertAlmostEqual(calcd_result, known_result, places=3)
 
     def test_calculate_batch_wtpt_1(self):
+        print_msg_box("TestLiquidViscosity \nbatch_wtpt_1")
         batch_result = self.batch_wtpt.calculate_liquid_viscosity(
                                                 temperature=self.temperature)
         calcd_result_1 = batch_result['Viscosity_liq_VESIcal'].loc['test_samp']
@@ -546,6 +650,7 @@ class TestLiquidViscosity(unittest.TestCase):
         self.assertAlmostEqual(calcd_result_1, known_result_1, places=3)
 
     def test_calculate_batch_wtpt_2(self):
+        print_msg_box("TestLiquidViscosity \nbatch_wtpt_2")
         batch_result = self.batch_wtpt.calculate_liquid_viscosity(
                                                 temperature=self.temperature)
         calcd_result_2 = batch_result['Viscosity_liq_VESIcal'].loc[
@@ -553,14 +658,15 @@ class TestLiquidViscosity(unittest.TestCase):
         known_result_2 = self.batch_test_giordano_spreadsheet_default_comp
         self.assertAlmostEqual(calcd_result_2, known_result_2, places=3)
 
-
     def test_calculate_single_molox(self):
+        print_msg_box("TestLiquidViscosity \nsingle_molox")
         calcd_result = v.calculate_liquid_viscosity(self.sample_molox,
                                             temperature=self.temperature).result
         known_result = self.giordano_default_viscosity
         self.assertAlmostEqual(calcd_result, known_result, places=3)
 
     def test_calculate_batch_molox_1(self):
+        print_msg_box("TestLiquidViscosity \nbatch_molox_1")
         batch_result = self.batch_molox.calculate_liquid_viscosity(
                                                 temperature=self.temperature)
         calcd_result_1 = batch_result['Viscosity_liq_VESIcal'].loc['test_samp']
@@ -568,6 +674,7 @@ class TestLiquidViscosity(unittest.TestCase):
         self.assertAlmostEqual(calcd_result_1, known_result_1, places=3)
 
     def test_calculate_batch_molox_2(self):
+        print_msg_box("TestLiquidViscosity \nbatch_molox_2")
         batch_result = self.batch_molox.calculate_liquid_viscosity(
                                                 temperature=self.temperature)
         calcd_result_2 = batch_result['Viscosity_liq_VESIcal'].loc[
@@ -576,6 +683,7 @@ class TestLiquidViscosity(unittest.TestCase):
         self.assertAlmostEqual(calcd_result_2, known_result_2, places=3)
 
     def test_normalize_giordano(self):
+        print_msg_box("TestLiquidViscosity \nnormalize_giordano")
         known_result = self.giordano_normalized
         calcd_result = {}
         calculation = v.thermo.giordano._normalize_Giordano(
@@ -632,6 +740,7 @@ class TestLiquidDensity(unittest.TestCase):
         self.densityx = 2620.832
 
     def test_calculate_single_wtpt(self):
+        print_msg_box("TestLiquidDensity \nsingle_wtpt")
         calcd_result = v.calculate_liquid_density(self.sample_wtpt,
                                                   temperature=self.temperature,
                                                   pressure=self.pressure).result
@@ -639,6 +748,7 @@ class TestLiquidDensity(unittest.TestCase):
         self.assertAlmostEqual(calcd_result, known_result, places=4)
 
     def test_calculate_batch_wtpt(self):
+        print_msg_box("TestLiquidDensity \nbatch_wtpt")
         batch_result = self.batch_wtpt.calculate_liquid_density(
                                             temperature=self.temperature,
                                             pressure=self.pressure)
@@ -647,6 +757,7 @@ class TestLiquidDensity(unittest.TestCase):
         self.assertAlmostEqual(calcd_result, known_result, places=4)
 
     def test_calculate_single_molox(self):
+        print_msg_box("TestLiquidDensity \nsingle_molox")
         calcd_result = v.calculate_liquid_density(self.sample_molox,
                                                   temperature=self.temperature,
                                                   pressure=self.pressure).result
@@ -654,6 +765,7 @@ class TestLiquidDensity(unittest.TestCase):
         self.assertAlmostEqual(calcd_result, known_result, places=4)
 
     def test_calculate_batch_molox(self):
+        print_msg_box("TestLiquidDensity \nbatch_molox")
         batch_result = self.batch_molox.calculate_liquid_density(
                                             temperature=self.temperature,
                                             pressure=self.pressure)

--- a/tests/test_importfile.py
+++ b/tests/test_importfile.py
@@ -3,6 +3,21 @@ import VESIcal as v
 import pandas as pd
 import pathlib
 
+def print_msg_box(msg, indent=1, width=None, title=None):
+    """Print message-box with optional title."""
+    lines = msg.split('\n')
+    space = " " * indent
+    if not width:
+        width = max(map(len, lines))
+    box = f'╔{"═" * (width + indent * 2)}╗\n'  # upper_border
+    if title:
+        box += f'║{space}{title:<{width}}{space}║\n'  # title
+        box += f'║{space}{"-" * len(title):<{width}}{space}║\n'  # underscore
+    box += ''.join([f'║{space}{line:<{width}}{space}║\n' for line in lines])
+    box += f'╚{"═" * (width + indent * 2)}╝'  # lower_border
+    print("\n")
+    print(box)
+
 # Allow unittest to find the file
 TEST_FILE = pathlib.Path(__file__).parent.joinpath("ImportTest.xlsx")
 
@@ -43,5 +58,6 @@ class TestImportExcel(unittest.TestCase):
         self.myfile = v.BatchFile(TEST_FILE)
 
     def test_ImportExcel(self):
+        print_msg_box("TestImportExcel")
         self.assertEqual(self.df, self.myfile.get_data(), 
                          'DataFrames are different')

--- a/tests/test_sample.py
+++ b/tests/test_sample.py
@@ -3,6 +3,21 @@ import VESIcal as v
 import numpy as np
 import pandas as pd
 
+def print_msg_box(msg, indent=1, width=None, title=None):
+    """Print message-box with optional title."""
+    lines = msg.split('\n')
+    space = " " * indent
+    if not width:
+        width = max(map(len, lines))
+    box = f'╔{"═" * (width + indent * 2)}╗\n'  # upper_border
+    if title:
+        box += f'║{space}{title:<{width}}{space}║\n'  # title
+        box += f'║{space}{"-" * len(title):<{width}}{space}║\n'  # underscore
+    box += ''.join([f'║{space}{line:<{width}}{space}║\n' for line in lines])
+    box += f'╚{"═" * (width + indent * 2)}╝'  # lower_border
+    print("\n")
+    print(box)
+
 class TestCreateSample(unittest.TestCase):
     def setUp(self):
         self.majors = pd.Series({'SiO2':    47.95,
@@ -139,6 +154,7 @@ class TestCreateSample(unittest.TestCase):
         self.sample_all = v.Sample(self.majors_all_species)
 
     def test_createSample(self):
+        print_msg_box("TestCreateSample")
         for ox in self.majors.index:
             self.assertEqual(self.sample._composition[ox],self.majors[ox])
         for ox in self.majors_all_species.index:
@@ -343,6 +359,7 @@ class TestGetComposition(unittest.TestCase):
         self.sample = v.Sample(self.majorsv)
 
     def test_default(self):
+        print_msg_box("TestGetComposition")
         composition = self.sample.get_composition()
         for ox in composition.index:
             self.assertEqual(composition[ox],self.majorsv[ox])


### PR DESCRIPTION
@simonwmatthews, I've tried my hand at fixing the bug where an np.array object cannot be passed to some models for degassing path calculations. But, I admit, I have trouble wrapping my head around some of the ways the calibration checks are working. The main difference I saw between Liu and Dixon (this behavior breaks in Liu but works in Dixon) is that Liu uses the crf_Between check to validate the pressure being between 0 and 5000 bars. Dixon uses crf_LessThan. I've changed Liu to use crf_GreaterThan and crf_LessThan.

Maybe the real answer is the the crf_Between is broken? But using LessThan and Greater than seems to work, allows for the calculation with the Liu model, and all tests are passing... then again, I'm also not 100% sure enough tests are implemented for the calibration check stuff (I say this out of ignorance, not because I think you didn't do that!).

I would really appreciate you taking a look at this and letting me know if you think this is a reasonable fix, or if it's too hacky and we need to do something else.