### PR TITLE
Fixed get_composition() bugs

### DIFF
--- a/VESIcal/thermo/giordano.py
+++ b/VESIcal/thermo/giordano.py
@@ -1,6 +1,7 @@
 from VESIcal import core
 
 import numpy as np
+import warnings as w
 
 giordano_oxide_mass = {'SiO2': 60.0843,
                        'TiO2': 79.8658,
@@ -38,11 +39,14 @@ def _normalize_Giordano(sample):
                                      asSampleClass=True)
 
     # convert FeO and Fe2O3 to FeOT as FeO
-    _sample_FeOT = (_sample.get_composition(units='wtpt_oxides',
-                                            oxide_masses=giordano_oxide_mass,
-                                            species='FeO') +
-                    0.8998*_sample.get_composition(units='wtpt_oxides',
-                                                   species='Fe2O3'))
+    with w.catch_warnings():
+        w.filterwarnings("ignore", message="Species Fe2O3 not found in composition, " +
+                                           "assigning value of 0.0")
+        _sample_FeOT = (_sample.get_composition(units='wtpt_oxides',
+                                                oxide_masses=giordano_oxide_mass,
+                                                species='FeO') +
+                        0.8998*_sample.get_composition(units='wtpt_oxides',
+                                                    species='Fe2O3'))
     _sample.change_composition({'FeO': _sample_FeOT, 'Fe2O3': 0.0})
 
     # if passed, convert F to F2O

--- a/tests/test_sample.py
+++ b/tests/test_sample.py
@@ -447,3 +447,43 @@ class TestGetComposition(unittest.TestCase):
     def test_formulawt_exclV(self):
         fw = self.sample.get_formulaweight(exclude_volatiles=True)
         self.assertEqual(np.round(self.majors_fw,2),np.round(fw,2))
+
+    def test_get_cation(self):
+        Si_conc = self.majorsv_molcations["Si"]
+
+        # get cation no units
+        get_Si_conc = self.sample.get_composition(species="Si")
+        self.assertEqual(np.round(Si_conc,2), np.round(get_Si_conc,2)) 
+
+        # get cation units='mol_cations'
+        get_Si_mol_cations = self.sample.get_composition(species="Si", units="mol_cations")
+        self.assertEqual(np.round(Si_conc, 2), np.round(get_Si_mol_cations, 2))
+
+        # get cation units='wtpt_oxides'
+        get_Si_wtpt_oxides = self.sample.get_composition(species="Si", units="wtpt_oxides")
+        self.assertEqual(np.round(Si_conc, 2), np.round(get_Si_wtpt_oxides, 2))
+        self.assertWarns(expected_warning=RuntimeWarning)
+
+        # get cation for cation not given a value by user
+        self.assertEqual(self.sample.get_composition(species="Cr"), 0.0)
+        self.assertWarns(expected_warning=RuntimeWarning)
+    
+    def test_get_oxide(self):
+        SiO2_conc = self.majorsv["SiO2"]
+
+        # get oxide no units
+        get_SiO2_conc = self.sample.get_composition(species="SiO2")
+        self.assertEqual(np.round(SiO2_conc,2), np.round(get_SiO2_conc,2)) 
+
+        # get oxide units='mol_cations'
+        get_SiO2_mol_cations = self.sample.get_composition(species="SiO2", units="mol_cations")
+        self.assertEqual(np.round(SiO2_conc, 2), np.round(get_SiO2_mol_cations, 2))
+        self.assertWarns(expected_warning=RuntimeWarning)
+
+        # get oxide units='wtpt_oxides'
+        get_SiO2_wtpt_oxides = self.sample.get_composition(species="SiO2", units="wtpt_oxides")
+        self.assertEqual(np.round(SiO2_conc, 2), np.round(get_SiO2_wtpt_oxides, 2))
+
+        # get oxide for oxide not given a value by user
+        self.assertEqual(self.sample.get_composition(species="Cr2O3"), 0.0)
+        self.assertWarns(expected_warning=RuntimeWarning)


### PR DESCRIPTION
Bug existed where it was not possible to get a cation composition from a composition given in terms of oxides. This was fixed, and the order of checks during a call to get_composition() was changed to ensure this behavior does return a composition. A user is warned if they pass units not compatible with what they requested (e.g., they requested wtpt_oxides for the species "Si" which is a cation). Users are also warned if they asked for a cation or oxide that exists in VESIcal's core.oxides or core.cations but is not defined with a value in their Sample's composition. In this case, 0.0 is returned. Since the addition of this warning meant that warning showed up in a confusing way when calling the giordano viscosity model, that particular warning was silenced in the place where that warning would be generated. This was due to translations between FeO, Fe2O3, and FeOT. New unit tests were added for get_composition() calls, including checks to make sure users are warned as intended.